### PR TITLE
Update functions.ino

### DIFF
--- a/ArduDome/functions.ino
+++ b/ArduDome/functions.ino
@@ -16,9 +16,13 @@ boolean writeStatus(int pin, boolean value) {
   return value;
 }
 
-// read status of pins (digital and analog)
 int readStatus(int pin) {
-  if (pin<=13) return dpin[pin]; else return analogRead(pin);
+ if (pin<=13) {
+  dpin[pin] = digitalRead(pin);
+  return dpin[pin];  
+ }else{
+  return analogRead(pin);
+ }
 }
 
 // verify if a char is a number


### PR DESCRIPTION
Sostituendo ls funzione readStatus nel modo suggerito, è possibile usare Ardudome anche per leggere i pin configurati come ingresso.
Il progetto è molto affidabile e personalmente lo uso in molte varianti; questa leggera modifica è la piu semplice e permette di usare la scheda anche per eventuali ingressi digitali.